### PR TITLE
Add basic Flask webapp with login and live script logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Azor Price Updater Webapp
+
+This repository contains tools to update Shopify variant prices and now includes a small web application to run them more easily.
+
+## Running the Web Application
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your Shopify credentials. Add login credentials:
+   ```
+   ADMIN_USERNAME=youruser
+   ADMIN_PASSWORD=yourpass
+   SECRET_KEY=random-string
+   ```
+3. Start the server:
+   ```bash
+   python run_webapp.py
+   ```
+4. Visit `http://localhost:5000` and log in with the credentials above.
+
+## Using the Updaters
+
+- **Percentage Updater** adjusts prices by a percentage and uses `project-root/scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs.
+- **Variant Updater** runs `tempo solution/update_prices.py` which updates prices using predefined surcharges. Click the run button and watch the log.
+
+The output from each script is streamed live to your browser so you can follow progress.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+python-dotenv

--- a/run_webapp.py
+++ b/run_webapp.py
@@ -1,0 +1,6 @@
+from webapp import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,16 @@
+from flask import Flask
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+def create_app():
+    app = Flask(__name__)
+    app.secret_key = os.getenv('SECRET_KEY', 'change-me')
+
+    from .auth import auth_bp
+    from .routes import main_bp
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+
+    return app

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session
+import os
+
+auth_bp = Blueprint('auth', __name__)
+
+ADMIN_USER = os.getenv('ADMIN_USERNAME', 'admin')
+ADMIN_PASS = os.getenv('ADMIN_PASSWORD', 'password')
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if username == ADMIN_USER and password == ADMIN_PASS:
+            session['user'] = username
+            return redirect(url_for('main.home'))
+        return render_template('login.html', error='Invalid credentials')
+    return render_template('login.html')
+
+@auth_bp.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('auth.login'))

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -1,0 +1,57 @@
+from flask import Blueprint, render_template, request, session, redirect, url_for, Response
+import subprocess, os
+
+main_bp = Blueprint('main', __name__)
+
+SCRIPTS = {
+    'percentage': os.path.join('project-root', 'scripts', 'update_prices_shopify.py'),
+    'variant': os.path.join('tempo solution', 'update_prices.py')
+}
+
+
+def login_required(view):
+    from functools import wraps
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if 'user' not in session:
+            return redirect(url_for('auth.login'))
+        return view(*args, **kwargs)
+    return wrapped
+
+@main_bp.route('/')
+@login_required
+def home():
+    return render_template('home.html')
+
+@main_bp.route('/percentage-updater')
+@login_required
+def percentage_updater():
+    return render_template('percentage.html')
+
+@main_bp.route('/variant-updater')
+@login_required
+def variant_updater():
+    return render_template('variant.html')
+
+
+def stream_process(cmd):
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    for line in iter(process.stdout.readline, ''):
+        yield f'data: {line.rstrip()}\n\n'
+    process.wait()
+    yield 'data: --done--\n\n'
+
+@main_bp.route('/stream/percentage')
+@login_required
+def stream_percentage():
+    percent = request.args.get('percent')
+    if not percent:
+        return 'Missing percent', 400
+    cmd = ['python3', SCRIPTS['percentage'], '--percent', percent]
+    return Response(stream_process(cmd), mimetype='text/event-stream')
+
+@main_bp.route('/stream/variant')
+@login_required
+def stream_variant():
+    cmd = ['python3', SCRIPTS['variant']]
+    return Response(stream_process(cmd), mimetype='text/event-stream')

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Azor Price Updater</title>
+    <style>
+        body { background-color: #f8f9fa; }
+        .navbar { background-color: #343a40; }
+        .navbar-brand, .nav-link, .navbar-text { color: #fff !important; }
+        .btn-brand { background-color: #008cba; color: #fff; }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Azor Updater</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto">
+        {% if session.get('user') %}
+        <li class="nav-item"><span class="navbar-text me-3">Logged in as {{ session['user'] }}</span></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="alert alert-danger">{{ messages[0] }}</div>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Welcome</h3>
+<p>Select an action:</p>
+<ul>
+  <li><a href="{{ url_for('main.percentage_updater') }}">Percentage Updater</a></li>
+  <li><a href="{{ url_for('main.variant_updater') }}">Variant Updater</a></li>
+</ul>
+{% endblock %}

--- a/webapp/templates/login.html
+++ b/webapp/templates/login.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h3 class="mb-3">Login</h3>
+    <form method="post">
+      <div class="mb-3">
+        <input class="form-control" type="text" name="username" placeholder="Username" required>
+      </div>
+      <div class="mb-3">
+        <input class="form-control" type="password" name="password" placeholder="Password" required>
+      </div>
+      {% if error %}<div class="text-danger mb-2">{{ error }}</div>{% endif %}
+      <button class="btn btn-brand" type="submit">Login</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/webapp/templates/percentage.html
+++ b/webapp/templates/percentage.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Percentage Price Update</h3>
+<div class="mb-3">
+  <input id="percent" class="form-control" type="number" step="0.01" placeholder="Enter percentage">
+</div>
+<button id="start" class="btn btn-brand">Run</button>
+<pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+{% endblock %}
+{% block scripts %}
+<script>
+  document.getElementById('start').onclick = function(){
+    const p = document.getElementById('percent').value;
+    const log = document.getElementById('log');
+    log.textContent='';
+    const es = new EventSource(`/stream/percentage?percent=${encodeURIComponent(p)}`);
+    es.onmessage = e => {
+      if(e.data === '--done--') es.close();
+      else log.textContent += e.data + '\n';
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+</script>
+{% endblock %}

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Variant Price Update</h3>
+<button id="start" class="btn btn-brand">Run Update</button>
+<pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+{% endblock %}
+{% block scripts %}
+<script>
+  document.getElementById('start').onclick = function(){
+    const log = document.getElementById('log');
+    log.textContent='';
+    const es = new EventSource('/stream/variant');
+    es.onmessage = e => {
+      if(e.data === '--done--') es.close();
+      else log.textContent += e.data + '\n';
+      log.scrollTop = log.scrollHeight;
+    };
+  };
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add simple Flask webapp with login protected by env vars
- stream output from price update scripts via server‑sent events
- provide forms/pages for percentage and variant updates
- style pages with Bootstrap and create README instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c3cb9f8dc832cbd880c8d1e966de9