### PR TITLE
Add editable variant surcharge form

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ This repository contains tools to update Shopify variant prices and now includes
 ## Using the Updaters
 
 - **Percentage Updater** adjusts prices by a percentage and uses `project-root/scripts/update_prices_shopify.py`. Enter the desired percentage and monitor the real-time log while the script runs.
-- **Variant Updater** runs `tempo solution/update_prices.py` which updates prices using predefined surcharges. Click the run button and watch the log.
+- **Variant Updater** runs `tempo solution/update_prices.py`. The page shows all surcharges from `tempo solution/variant_prices.json`. Edit the values for each chain and click **Save Changes** to update the file. Then use the **Run Update** button to apply the prices while the real-time log streams.
 
 The output from each script is streamed live to your browser so you can follow progress.

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -1,7 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
 <h3>Variant Price Update</h3>
-<button id="start" class="btn btn-brand">Run Update</button>
+<form method="post">
+  {% for cat, chains in surcharges.items() %}
+  <h5 class="mt-3">{{ cat|capitalize }}</h5>
+  {% for chain, val in chains.items() %}
+  <div class="mb-2 row g-2 align-items-center">
+    <label class="col-sm-4 col-form-label">{{ chain }}</label>
+    <div class="col-sm-4">
+      <input class="form-control" type="number" step="0.01" name="{{ cat }}_{{ chain.replace(' ', '_') }}" value="{{ val }}">
+    </div>
+  </div>
+  {% endfor %}
+  {% endfor %}
+  <button class="btn btn-brand mt-2" type="submit">Save Changes</button>
+</form>
+<button id="start" class="btn btn-brand mt-3">Run Update</button>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
 {% endblock %}
 {% block scripts %}


### PR DESCRIPTION
## Summary
- add editing logic to `variant_updater` route and load surcharges from JSON
- display a form in `variant.html` for editing bracelet and collier surcharges
- update README with instructions for editing variant surcharges

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c4892cc34832ca58a564ffad36fb6