### PR TITLE
Improve UI feedback and navigation

### DIFF
--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -44,12 +44,12 @@ def variant_updater():
                 try:
                     updated[cat][chain] = float(val)
                 except ValueError:
-                    flash(f"Invalid value for {chain}")
+                    flash(f"Invalid value for {chain}", 'error')
                     return render_template('variant.html', surcharges=surcharges)
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(updated, f, indent=2)
         surcharges = updated
-        flash('Surcharges saved.')
+        flash('Surcharges saved.', 'success')
 
     return render_template('variant.html', surcharges=surcharges)
 

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -9,7 +9,9 @@
         body { background-color: #f8f9fa; }
         .navbar { background-color: #343a40; }
         .navbar-brand, .nav-link, .navbar-text { color: #fff !important; }
+        .nav-link.active { font-weight: bold; }
         .btn-brand { background-color: #008cba; color: #fff; }
+        h3, h5 { margin-top: 1rem; }
     </style>
 </head>
 <body>
@@ -17,19 +19,32 @@
   <div class="container-fluid">
     <a class="navbar-brand" href="/">Azor Updater</a>
     <div class="collapse navbar-collapse">
+      {% if session.get('user') %}
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link {{ 'active' if request.path == url_for('main.home') else '' }}" href="{{ url_for('main.home') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {{ 'active' if request.path == url_for('main.percentage_updater') else '' }}" href="{{ url_for('main.percentage_updater') }}">Percentage</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {{ 'active' if request.path == url_for('main.variant_updater') else '' }}" href="{{ url_for('main.variant_updater') }}">Variant</a>
+        </li>
+      </ul>
       <ul class="navbar-nav ms-auto">
-        {% if session.get('user') %}
         <li class="nav-item"><span class="navbar-text me-3">Logged in as {{ session['user'] }}</span></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
-        {% endif %}
       </ul>
+      {% endif %}
     </div>
   </div>
 </nav>
 <div class="container py-4">
-    {% with messages = get_flashed_messages() %}
+    {% with messages = get_flashed_messages(with_categories=True) %}
       {% if messages %}
-        <div class="alert alert-danger">{{ messages[0] }}</div>
+        {% for category, msg in messages %}
+          <div class="alert alert-{{ 'danger' if category == 'error' else category }}">{{ msg }}</div>
+        {% endfor %}
       {% endif %}
     {% endwith %}
     {% block content %}{% endblock %}

--- a/webapp/templates/percentage.html
+++ b/webapp/templates/percentage.html
@@ -5,18 +5,33 @@
   <input id="percent" class="form-control" type="number" step="0.01" placeholder="Enter percentage">
 </div>
 <button id="start" class="btn btn-brand">Run</button>
+<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+<div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
 {% block scripts %}
 <script>
-  document.getElementById('start').onclick = function(){
+  const startBtn = document.getElementById('start');
+  const spinner = document.getElementById('spinner');
+  const status = document.getElementById('status');
+  startBtn.onclick = function(){
     const p = document.getElementById('percent').value;
     const log = document.getElementById('log');
     log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
     const es = new EventSource(`/stream/percentage?percent=${encodeURIComponent(p)}`);
     es.onmessage = e => {
-      if(e.data === '--done--') es.close();
-      else log.textContent += e.data + '\n';
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        status.textContent = 'Update completed!';
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\n';
+      }
       log.scrollTop = log.scrollHeight;
     };
   };

--- a/webapp/templates/variant.html
+++ b/webapp/templates/variant.html
@@ -17,17 +17,32 @@
   <button class="btn btn-brand mt-2" type="submit">Save Changes</button>
 </form>
 <button id="start" class="btn btn-brand mt-3">Run Update</button>
+<div id="spinner" class="spinner-border text-primary ms-2 d-none" role="status"></div>
 <pre id="log" class="mt-3 bg-light p-2" style="height:300px;overflow:auto;"></pre>
+<div id="status" class="alert alert-success d-none mt-2"></div>
 {% endblock %}
 {% block scripts %}
 <script>
-  document.getElementById('start').onclick = function(){
+  const startBtn = document.getElementById('start');
+  const spinner = document.getElementById('spinner');
+  const status = document.getElementById('status');
+  startBtn.onclick = function(){
     const log = document.getElementById('log');
     log.textContent='';
+    status.classList.add('d-none');
+    spinner.classList.remove('d-none');
+    startBtn.disabled = true;
     const es = new EventSource('/stream/variant');
     es.onmessage = e => {
-      if(e.data === '--done--') es.close();
-      else log.textContent += e.data + '\n';
+      if(e.data === '--done--') {
+        es.close();
+        spinner.classList.add('d-none');
+        startBtn.disabled = false;
+        status.textContent = 'Update completed!';
+        status.classList.remove('d-none');
+      } else {
+        log.textContent += e.data + '\n';
+      }
       log.scrollTop = log.scrollHeight;
     };
   };


### PR DESCRIPTION
## Summary
- add navbar links with active state
- show flash messages with categories
- provide progress spinner and completion alert on updater pages
- categorize flashes in `routes.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c60c94558832cad041d5751e6b080